### PR TITLE
Corrección error de tipeo clase 2.

### DIFF
--- a/version_InOrder/T02_Representacion_de_la_Informacion_Parte_2/clase.tex
+++ b/version_InOrder/T02_Representacion_de_la_Informacion_Parte_2/clase.tex
@@ -233,7 +233,7 @@
 
 \begin{frame}[fragile,t]
     \frametitle{Números Fraccionarios}
-    Existen múltiples formas de codificar números fraccionaros.\\
+    Existen múltiples formas de codificar números fraccionarios.\\
     Vamos a analizar solo dos de ellas.\\
     \vspace{0.5cm}
     \pause


### PR DESCRIPTION
Se cambió "fraccionaros" por "fraccionarios", en la sección de introducción a las 2 formas de codificar números fraccionarios de la clase 2.