### PR TITLE
Error de tipeo Clase 17

### DIFF
--- a/version_InOrder/T17_Planificacion_de_Procesos/clase.tex
+++ b/version_InOrder/T17_Planificacion_de_Procesos/clase.tex
@@ -340,7 +340,7 @@
     \begin{textblock}{140}(10,65)
     \only<9->{
     \begin{tcolorbox}[size=small,width=\textwidth,sharp corners,title={}] \small
-    Este algoritmo es \textbf{óptimo} para minimiza el tiempo de espera promedio.\\
+    Este algoritmo es \textbf{óptimo} para minimizar el tiempo de espera promedio.\\
     Sin embargo, no lo es, ya que se cuenta con una predicción del tiempo de ráfaga de cada proceso.
     \end{tcolorbox}
     }


### PR DESCRIPTION
En la diapositiva de Shortest Job First, se cambió "minimiza", por "minimizar".