### PR TITLE
Agrego quantum de 10ms en ejemplo de SRTF

### DIFF
--- a/version_InOrder/T17_Planificacion_de_Procesos/clase.tex
+++ b/version_InOrder/T17_Planificacion_de_Procesos/clase.tex
@@ -355,7 +355,7 @@
     \end{textblock}
     \begin{textblock}{50}(95,12)
     \only<2->{
-    \textcolor{gray}{\small Ejemplo}\\ \vspace{-0.3cm}
+    \textcolor{gray}{\small Ejemplo} \hspace{2cm} \scriptsize \emph{quantum = $10$}\\ \vspace{-0.2cm}
     \textcolor{gray}{\rule{\linewidth}{0.8pt}}
     \begin{tabular}{C{1.2cm}|C{1.2cm}|C{1.2cm}l}
     \small Proceso     & \scriptsize Tiempo de llegada & \scriptsize Tiempo de ráfaga & \\ %\hline \hline


### PR DESCRIPTION
Se agrega línea \hspace{2cm} \scriptsize \emph{quantum = $10$}\\ \vspace{-0.2cm} para aclarar el valor del quantum en el ejemplo de planificación SRTF.